### PR TITLE
Changed wi-own-701 classes to match the right code

### DIFF
--- a/css/weather-icons.css
+++ b/css/weather-icons.css
@@ -1366,7 +1366,7 @@
   content: "\f01b";
 }
 .wi-owm-701:before {
-  content: "\f01a";
+  content: "\f014";
 }
 .wi-owm-711:before {
   content: "\f062";
@@ -1549,7 +1549,7 @@
   content: "\f00a";
 }
 .wi-owm-day-701:before {
-  content: "\f009";
+  content: "\f003";
 }
 .wi-owm-day-711:before {
   content: "\f062";
@@ -1723,7 +1723,7 @@
   content: "\f02a";
 }
 .wi-owm-night-701:before {
-  content: "\f029";
+  content: "\f04a";
 }
 .wi-owm-night-711:before {
   content: "\f062";


### PR DESCRIPTION
According to open weather map, code 701 is for mist. Because mist is not available I changed it to fog. The file had the code for showers instead.